### PR TITLE
3-convert-booleans-string-to-bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Having an env set to `true`, `false` or `null` will now correctly returns a boolean or `null` instead of a string.
+
 ## [0.1.1] 2020-09-07
 
 ### Added

--- a/src/Env.php
+++ b/src/Env.php
@@ -67,7 +67,18 @@ class Env
         self::boot();
 
         if (isset($_ENV[$name])) {
-            return $_ENV[$name];
+            $value = $_ENV[$name];
+
+            switch ($value) {
+                case "true":
+                    return true;
+                case "false":
+                    return false;
+                case "null":
+                    return;
+                default:
+                    return $value;
+            }
         }
 
         if ($fallback !== null) {

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -65,3 +65,21 @@ it("should throw an exception if the path is not a folder", function (): void {
 
     Env::setFolderPath(__DIR__ . "/misc/.env");
 });
+
+it("should return a boolean", function (): void {
+    Env::setFolderPath(__DIR__ . "/misc");
+
+    expect(Env::get("APP_DEBUG"))->toBeTrue();
+});
+
+it("should return false", function (): void {
+    Env::setFolderPath(__DIR__ . "/misc");
+
+    expect(Env::get("SESSION_ENABLED"))->toBeFalse();
+});
+
+it("should return null", function (): void {
+    Env::setFolderPath(__DIR__ . "/misc");
+
+    expect(Env::get("GMAIL_API_KEY"))->tobeNull();
+});

--- a/tests/misc/.env
+++ b/tests/misc/.env
@@ -1,1 +1,4 @@
 APP_NAME=Folded
+APP_DEBUG=true
+SESSION_ENABLED=false
+GMAIL_API_KEY=null


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when using booleans or null values in an env variable would return a string when getting its value.

## Breaking

None.