### PR TITLE
8-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` to `function_exists` statements.
+
 ## [0.1.3] 2020-09-18
 
 ### Fixed

--- a/src/getAllConfig.php
+++ b/src/getAllConfig.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getAllConfig")) {
+if (!function_exists("Folded\getAllConfig")) {
     /**
      * Returns all the configurations.
      *

--- a/src/getConfig.php
+++ b/src/getConfig.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getConfig")) {
+if (!function_exists("Folded\getConfig")) {
     /**
      * Get the configuration value.
      *

--- a/src/hasConfig.php
+++ b/src/hasConfig.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("hasConfig")) {
+if (!function_exists("Folded\hasConfig")) {
     /**
      * Returns true if the configuration is found, else returns false.
      *

--- a/src/hasEnv.php
+++ b/src/hasEnv.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("hasEnv")) {
+if (!function_exists("Folded\hasEnv")) {
     /**
      * Returns true if the env variable is present, else returns false.
      *

--- a/src/setConfigFolderPath.php
+++ b/src/setConfigFolderPath.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("setConfigFolderPath")) {
+if (!function_exists("Folded\setConfigFolderPath")) {
     /**
      * Set the folder containing the files storing configurations.
      *

--- a/src/setEnvFolderPath.php
+++ b/src/setEnvFolderPath.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("setEnvFolderPath")) {
+if (!function_exists("Folded\setEnvFolderPath")) {
     /**
      * Set the folder path to find the .env file.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when namespace `Folded` was missing from `function_exists` statements.

## Breaking

None.